### PR TITLE
Fix: HTTP headers are case-insensitve

### DIFF
--- a/src/Request/Comparator/Generic.php
+++ b/src/Request/Comparator/Generic.php
@@ -48,7 +48,7 @@ class Generic implements ComparatorInterface
         if (!$this->hasAll($subject->getQueryParams(), $exemplar->getQueryParams())) {
             return false;
         }
-        if (!$this->hasAll($subject->getHeaders(), $exemplar->getHeaders())) {
+        if (!$this->hasAll(array_change_key_case($subject->getHeaders(), CASE_LOWER), array_change_key_case($exemplar->getHeaders(), CASE_LOWER))) {
             return false;
         }
         if (!$this->hasAll($subject->getCookieParams(), $exemplar->getCookieParams())) {


### PR DESCRIPTION
The comparator expects HTTPS to be case-sensitive. However according to RFC2616 (https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2) they are case-insensitive. This leads to unexpected bad requests.