### PR TITLE
Change PHP support (5.5-7.0 -> 5.6-7.3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
   - hhvm
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Operational fake API server can be stood up in a matter of minutes.
 
 ### System Requirements
 
-* Interpreter [PHP](http://www.php.net/) 5.5 or newer
+* Interpreter [PHP](http://www.php.net/) 5.6 or newer
 
 * Dependency manager [Composer](https://getcomposer.org/)
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=5.6.0",
         "zendframework/zend-diactoros": "~1.3"
     },
     "require-dev": {


### PR DESCRIPTION
PHP 5.5. was EOL in June 2016. Also Travis-CI build for PHP 5.5 fails, because the default distro used by Travis-CI does not support this version anymore.

You can fix this by setting a legacy-distro in travis.yml (https://travis-ci.community/t/php-5-4-and-5-5-archives-missing/3723/4),  however removing the version feels better.